### PR TITLE
Improve theme consistency and calendar visibility across screens

### DIFF
--- a/lib/screens/book_selection/book_selection_screen.dart
+++ b/lib/screens/book_selection/book_selection_screen.dart
@@ -41,7 +41,7 @@ class BookSelectionScreen extends StatelessWidget {
           style: AppFonts.bold(
             context,
             size: FontSize.large,
-          ).copyWith(color: const Color(0xFFE0C097)),
+          ).copyWith(color: context.appBarTitleColor),
         ),
         leading: IconButton(
           onPressed: () => context.pop(),

--- a/lib/screens/book_selection/book_selection_screen.dart
+++ b/lib/screens/book_selection/book_selection_screen.dart
@@ -35,8 +35,14 @@ class BookSelectionScreen extends StatelessWidget {
       backgroundColor: context.backgroundColor,
       appBar: AppBar(
         toolbarHeight: 48,
-        backgroundColor: context.backgroundColor,
-        title: Text(title, style: AppFonts.bold(context, size: FontSize.large)),
+        backgroundColor: context.appBarColor,
+        title: Text(
+          title,
+          style: AppFonts.bold(
+            context,
+            size: FontSize.large,
+          ).copyWith(color: const Color(0xFFE0C097)),
+        ),
         leading: IconButton(
           onPressed: () => context.pop(),
           icon: Icon(

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -31,7 +31,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 widget.title,
                 style: AppFonts.bold(
                   context,
-                ).copyWith(color: const Color(0xFFE0C097), fontSize: 24),
+                ).copyWith(color: context.appBarTitleColor, fontSize: 24),
               ),
             ),
 
@@ -88,7 +88,7 @@ class _HomeScreenState extends State<HomeScreen> {
               Text(
                 widget.title,
                 style: GoogleFonts.allura(
-                  color: const Color(0xFFE0C097),
+                  color: context.appBarTitleColor,
                   fontSize: 35,
                   fontWeight: FontWeight.w400,
                 ),
@@ -97,7 +97,7 @@ class _HomeScreenState extends State<HomeScreen> {
               Text(
                 'Volume I',
                 style: AppFonts.normal(context).copyWith(
-                  color: const Color(0xFFE0C097),
+                  color: context.appBarTitleColor,
                   fontSize: 15,
                   fontWeight: FontWeight.w400,
                 ),

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -52,7 +52,10 @@ class SettingsScreen extends StatelessWidget {
       appBar: AppBar(
         toolbarHeight: 48,
         backgroundColor: context.appBarColor,
-        title: Text('Settings', style: AppFonts.bold(context)),
+        title: Text(
+          'Settings',
+          style: AppFonts.bold(context).copyWith(color: const Color(0xFFE0C097)),
+        ),
         leading: IconButton(
           onPressed: context.pop,
           icon: Icon(

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -54,7 +54,9 @@ class SettingsScreen extends StatelessWidget {
         backgroundColor: context.appBarColor,
         title: Text(
           'Settings',
-          style: AppFonts.bold(context).copyWith(color: const Color(0xFFE0C097)),
+          style: AppFonts.bold(
+            context,
+          ).copyWith(color: context.appBarTitleColor),
         ),
         leading: IconButton(
           onPressed: context.pop,

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -11,6 +11,7 @@ class AppColors {
   static const Color lightBackground = Color(0xFFFFFFFF);
   static const Color lightSurface = Color(0xFFFFFFFF);
   static const Color lightAppBar = Color(0xFF8B1A1A);
+  static const Color lightAppBarTitle = Color(0xFFE0C097);
   static const Color lightOnBackground = Color(0xFF1A1A1A);
   static const Color lightOnSurface = Color(0xFFD6D6D6);
   static const Color lightError = Color(0xFFBA1A1A);
@@ -19,6 +20,7 @@ class AppColors {
   // Dark theme
   static const Color darkBackground = Color(0xFF1A1A1A);
   static const Color darkSurface = Color(0xFF8B1A1A);
+  static const Color darkAppBarTitle = Color(0xFFE0C097);
   static const Color darkOnBackground = Color(0xFFE6E1E5);
   static const Color darkOnSurface = Color(0xFFE6E1E5);
   static const Color darkError = Color(0xFFFFB4AB);
@@ -137,6 +139,8 @@ extension ThemeColors on BuildContext {
   Color get errorColor => Theme.of(this).colorScheme.error;
   Color get appBarColor =>
       isDarkMode ? AppColors.darkSurface : AppColors.lightAppBar;
+  Color get appBarTitleColor =>
+      isDarkMode ? AppColors.darkAppBarTitle : AppColors.lightAppBarTitle;
 
   Color get primaryButtonBGColor =>
       isDarkMode

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -71,6 +71,8 @@ class AppColors {
   // Calendar – Headers & cell borders
   static const Color calendarDayHeaderLight = Color(0xFF000000);
   static const Color calendarDayHeaderDark = Color(0xFFFFFFFF);
+  static const Color calendarCurrentWeekdayLight = Color(0xFF8B1A1A);
+  static const Color calendarCurrentWeekdayDark = Color(0xFFE6B453);
 
   static const Color calendarCellBorderLight = Color(0xFF313131);
   static const Color calendarCellBorderDark = Color(0xFFFFFFFF);
@@ -191,6 +193,11 @@ extension ThemeColors on BuildContext {
       isDarkMode
           ? AppColors.calendarDayHeaderDark
           : AppColors.calendarDayHeaderLight;
+
+  Color get calendarCurrentWeekday =>
+      isDarkMode
+          ? AppColors.calendarCurrentWeekdayDark
+          : AppColors.calendarCurrentWeekdayLight;
 
   Color get calendarCellBorder =>
       isDarkMode

--- a/lib/theme/bloc/theme_bloc.dart
+++ b/lib/theme/bloc/theme_bloc.dart
@@ -186,7 +186,7 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
       useMaterial3: true,
       brightness: Brightness.dark,
       colorScheme: const ColorScheme.dark(
-        primary: p,
+        primary: AppColors.darkAccent,
         onPrimary: Colors.white,
         secondary: AppColors.secondaryVariant,
         surface: AppColors.darkSurface,

--- a/lib/theme/bloc/theme_bloc.dart
+++ b/lib/theme/bloc/theme_bloc.dart
@@ -179,7 +179,6 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
   }
 
   static ThemeData _createDarkTheme() {
-    const p = AppColors.primary;
     const on = AppColors.darkOnBackground;
 
     return ThemeData(

--- a/lib/widgets/calendar_widget.dart
+++ b/lib/widgets/calendar_widget.dart
@@ -287,6 +287,7 @@ class _FamilyAltarCalendarState extends State<FamilyAltarCalendar>
               child: SfCalendar(
                 controller: _calendarController,
                 view: CalendarView.month,
+                todayHighlightColor: context.calendarCurrentWeekday,
                 // Let parent scroll view handle drag gestures on
                 // small landscape screens.
                 initialDisplayDate: _currentDate,


### PR DESCRIPTION
- Change app bar title color in BookSelectionScreen and SettingsScreen to a  same as home screen.
- change colors for current weekday in calendar for both light and dark themes so that the weekday is more visible on both themes. 
- Update primary color in ThemeBloc to use darkAccent.
- Refactor app bar title color across BookSelectionScreen, HomeScreen, and SettingsScreen to use context.appBarTitleColor for consistency.
- fixed linter errors
