### PR TITLE
Refactor calendar widget layout to stabilize month cell sizes by reserving height for 6 week rows , this fixes image position to not be reactive to calendar size

### DIFF
--- a/lib/screens/book_selection/book_selection_screen.dart
+++ b/lib/screens/book_selection/book_selection_screen.dart
@@ -391,7 +391,7 @@ class _BookInnerPage extends StatelessWidget {
                           iconSize: 18,
                           padding: EdgeInsets.zero,
                           onPressed: onClose,
-                          icon: Icon(Icons.close, color: Colors.black),
+                          icon: const Icon(Icons.close, color: Colors.black),
                           splashRadius: 20,
                         ),
                       ),

--- a/lib/screens/book_selection/book_selection_screen.dart
+++ b/lib/screens/book_selection/book_selection_screen.dart
@@ -47,7 +47,7 @@ class BookSelectionScreen extends StatelessWidget {
           onPressed: () => context.pop(),
           icon: Icon(
             Icons.arrow_back,
-            color: context.textColor,
+            color: context.appBarLeadingIconColor,
             size: AppIcons.getIconSize(IconSize.medium),
           ),
         ),
@@ -391,7 +391,7 @@ class _BookInnerPage extends StatelessWidget {
                           iconSize: 18,
                           padding: EdgeInsets.zero,
                           onPressed: onClose,
-                          icon: Icon(Icons.close, color: context.textColor),
+                          icon: Icon(Icons.close, color: Colors.black),
                           splashRadius: 20,
                         ),
                       ),

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -162,7 +162,7 @@ class _HomeScreenState extends State<HomeScreen>
         leading: Builder(
           builder:
               (context) => IconButton(
-                icon: Icon(Icons.menu, color: context.textColor),
+                icon: Icon(Icons.menu, color: context.appBarLeadingIconColor),
                 onPressed: () => Scaffold.of(context).openDrawer(),
               ),
         ),

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -62,7 +62,7 @@ class SettingsScreen extends StatelessWidget {
           onPressed: context.pop,
           icon: Icon(
             Icons.arrow_back,
-            color: context.textColor,
+            color: context.appBarLeadingIconColor,
             size: AppIcons.getIconSize(IconSize.medium),
           ),
         ),

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -142,6 +142,7 @@ extension ThemeColors on BuildContext {
   Color get appBarTitleColor =>
       isDarkMode ? AppColors.darkAppBarTitle : AppColors.lightAppBarTitle;
 
+  Color get appBarLeadingIconColor => AppColors.darkOnBackground;
   Color get primaryButtonBGColor =>
       isDarkMode
           ? AppColors.primaryButtonBGColorDark

--- a/lib/utils/utilities.dart
+++ b/lib/utils/utilities.dart
@@ -41,10 +41,11 @@ String formatReadingForSharing(Reading reading) {
     |$scripture
     |
     |$quote\n
+    |$sermonTitleAndDate
+    |
     |Daily Reading:
     |$dailyReading
-    |
-    |$sermonTitleAndDate
+
   '''.stripMargin();
 
   final fullShareText =

--- a/lib/utils/utilities.dart
+++ b/lib/utils/utilities.dart
@@ -34,6 +34,7 @@ String formatReadingForSharing(Reading reading) {
   final scripture = reading.scripture.replaceAll('\n', '').trim();
   final quote = reading.quote.replaceAll('\n', '').trim();
   final dailyReading = reading.dailyReading.replaceAll('\n', '').trim();
+  final sermonTitleAndDate = reading.title.replaceAll('\n', '').trim();
 
   final shareContent =
       '''
@@ -42,6 +43,8 @@ String formatReadingForSharing(Reading reading) {
     |$quote\n
     |Daily Reading:
     |$dailyReading
+    |
+    |$sermonTitleAndDate
   '''.stripMargin();
 
   final fullShareText =

--- a/lib/widgets/calendar_widget.dart
+++ b/lib/widgets/calendar_widget.dart
@@ -17,6 +17,8 @@ class FamilyAltarCalendar extends StatefulWidget {
 
 class _FamilyAltarCalendarState extends State<FamilyAltarCalendar>
     with SingleTickerProviderStateMixin {
+  static const int _monthLayoutRowCount = 6;
+
   // Same shortestSide breakpoint as HomeScreen; cap width lower on tablets so
   // month cells are not oversized.
   static bool _isPhoneLayout(BuildContext context) {
@@ -55,13 +57,6 @@ class _FamilyAltarCalendarState extends State<FamilyAltarCalendar>
   }
 
   // --- Logic Helpers ---
-
-  int _weeksInMonth(DateTime date) {
-    final firstDay = DateTime(date.year, date.month);
-    final daysInMonth = DateUtils.getDaysInMonth(date.year, date.month);
-    final leadingDays = firstDay.weekday % DateTime.daysPerWeek;
-    return ((leadingDays + daysInMonth) / DateTime.daysPerWeek).ceil();
-  }
 
   static int _daysInYear(int year) {
     final isLeapYear = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
@@ -293,25 +288,25 @@ class _FamilyAltarCalendarState extends State<FamilyAltarCalendar>
                   calendarMaxWidth,
                 );
             var cellSize = (calendarCardWidth - containerPadding) / 7;
-            final rows = _weeksInMonth(_currentDate);
             const topSectionReserve = 152.0;
             final heightForCalendarCard =
                 constraints.maxHeight - 8 - topSectionReserve;
             if (!tabletLandscape &&
-                rows > 0 &&
                 heightForCalendarCard > viewHeaderH + containerPadding) {
               final fromHeight =
                   (heightForCalendarCard -
                       viewHeaderH -
                       containerPadding) /
-                  rows;
+                  _monthLayoutRowCount;
               if (fromHeight > 0 && fromHeight < cellSize) {
                 cellSize = fromHeight;
                 calendarCardWidth = cellSize * 7 + containerPadding;
               }
             }
             final calendarCardHeight =
-                viewHeaderH + rows * cellSize + containerPadding;
+                viewHeaderH +
+                    _monthLayoutRowCount * cellSize +
+                    containerPadding;
 
             final calendarCard = Container(
               decoration: BoxDecoration(


### PR DESCRIPTION
- Refactor colors in home (burger menu icon), and book selection, settings back buttons to use same color on both dark mode and light mode. 
- Refactor calendar widget layout to stabilize month cell sizes by reserving height for 6 week rows , this fixes image position to not be reactive to calendar size
- Update sharing format to include sermon title and date.

Home Screen Video


https://github.com/user-attachments/assets/5e8fe757-86d3-4365-b218-d8cf39351119


