### PR TITLE
Notification bug fix attempt 2 an

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "Bash(flutter analyze *)"
+    ]
+  }
+}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -57,6 +57,7 @@ android {
             if (keystorePropertiesFile.exists()) {
                 signingConfig = signingConfigs.getByName("release")
             }
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
     flavorDimensions += "default"

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,3 @@
+# flutter_local_notifications: prevent R8 from stripping serialization classes
+# used by the scheduled notification receiver at alarm-fire time.
+-keep class com.dexterous.** { *; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,5 +55,4 @@
     </queries>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 </manifest>

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -97,18 +97,14 @@ class NotificationService {
     const androidInit = AndroidInitializationSettings('ic_notification');
     // Disable the auto-request flags so the OS dialog only fires when the user
     // explicitly enables notifications via the settings toggle, not on every
-    // cold start. The explicit request happens in _requestNotificationsPermission.
-    // defaultPresent* flags must be true so notifications show even while the
-    // app is in the foreground (iOS suppresses them otherwise).
+    // cold start. The explicit request happens in
+    // _requestNotificationsPermission.
+    // Package defaults keep defaultPresent* true so notifications show in the
+    // foreground on iOS (it suppresses them otherwise).
     const iosInit = DarwinInitializationSettings(
       requestAlertPermission: false,
       requestBadgePermission: false,
       requestSoundPermission: false,
-      defaultPresentAlert: true,
-      defaultPresentBadge: true,
-      defaultPresentSound: true,
-      defaultPresentBanner: true,
-      defaultPresentList: true,
     );
     const initSettings = InitializationSettings(
       android: androidInit,
@@ -152,8 +148,8 @@ class NotificationService {
       // versions), fall back to areNotificationsEnabled() as the authoritative
       // check — that call only needs applicationContext, not an activity.
       final granted = await android.requestNotificationsPermission();
-      if (granted == true) return true;
-      return await android.areNotificationsEnabled() == true;
+      if (granted ?? false) return true;
+      return (await android.areNotificationsEnabled()) ?? false;
     }
 
     final ios =

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -21,7 +21,16 @@ class _NotificationBootstrapperState extends State<NotificationBootstrapper> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       try {
-        await NotificationService().initAndScheduleDaily();
+        final hasPrompted =
+            await NotificationSettings.hasPromptedForPermission();
+        if (!hasPrompted) {
+          // First launch: mark as prompted before asking so a crash/kill during
+          // the dialog doesn't result in repeated prompts on next open.
+          await NotificationSettings.setHasPromptedForPermission();
+          await NotificationService().enableDailyNotifications();
+        } else {
+          await NotificationService().initAndScheduleDaily();
+        }
       } catch (e, st) {
         debugPrint('Notification init failed: $e');
         debugPrint('$st');
@@ -86,7 +95,21 @@ class NotificationService {
 
   Future<void> _initialize() async {
     const androidInit = AndroidInitializationSettings('ic_notification');
-    const iosInit = DarwinInitializationSettings();
+    // Disable the auto-request flags so the OS dialog only fires when the user
+    // explicitly enables notifications via the settings toggle, not on every
+    // cold start. The explicit request happens in _requestNotificationsPermission.
+    // defaultPresent* flags must be true so notifications show even while the
+    // app is in the foreground (iOS suppresses them otherwise).
+    const iosInit = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+      defaultPresentAlert: true,
+      defaultPresentBadge: true,
+      defaultPresentSound: true,
+      defaultPresentBanner: true,
+      defaultPresentList: true,
+    );
     const initSettings = InitializationSettings(
       android: androidInit,
       iOS: iosInit,
@@ -119,12 +142,34 @@ class NotificationService {
 
   Future<bool> _requestNotificationsPermission() async {
     final android =
-        _plugin
-            .resolvePlatformSpecificImplementation<
-              AndroidFlutterLocalNotificationsPlugin
-            >();
+        _plugin.resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    if (android != null) {
+      // requestNotificationsPermission() returns true immediately (no dialog)
+      // if permission is already granted, and shows the OS dialog otherwise.
+      // If it returns false/null (e.g. activity context unavailable on some
+      // versions), fall back to areNotificationsEnabled() as the authoritative
+      // check — that call only needs applicationContext, not an activity.
+      final granted = await android.requestNotificationsPermission();
+      if (granted == true) return true;
+      return await android.areNotificationsEnabled() == true;
+    }
 
-    return await android?.requestNotificationsPermission() ?? true;
+    final ios =
+        _plugin.resolvePlatformSpecificImplementation<
+          IOSFlutterLocalNotificationsPlugin
+        >();
+    if (ios != null) {
+      return await ios.requestPermissions(
+            alert: true,
+            badge: true,
+            sound: true,
+          ) ??
+          false;
+    }
+
+    return true;
   }
 
   Future<bool> _areNotificationsAllowed() async {
@@ -160,7 +205,7 @@ class NotificationService {
         ),
       ),
       matchDateTimeComponents: DateTimeComponents.time,
-      androidScheduleMode: AndroidScheduleMode.inexact,
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
     );
   }
 

--- a/lib/notification_settings.dart
+++ b/lib/notification_settings.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 class NotificationSettings {
   static const String _enabledKey = 'notifications_enabled';
   static const String _timeKey = 'notification_time_minutes';
+  static const String _hasPromptedKey = 'notifications_has_prompted';
   static const TimeOfDay defaultTime = TimeOfDay(hour: 8, minute: 0);
 
   static Future<bool> isEnabled() async {
@@ -14,6 +15,16 @@ class NotificationSettings {
   static Future<void> setEnabled({required bool enabled}) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_enabledKey, enabled);
+  }
+
+  static Future<bool> hasPromptedForPermission() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_hasPromptedKey) ?? false;
+  }
+
+  static Future<void> setHasPromptedForPermission() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_hasPromptedKey, true);
   }
 
   static Future<TimeOfDay> getTimeOfDay() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+5
+version: 1.0.0+8
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
had to pull claude to assist :

 lib/notification_service.dart

  NotificationBootstrapper — on first launch (hasPrompted = false), calls enableDailyNotifications() to trigger the OS
  permission dialog. On subsequent launches, calls initAndScheduleDaily() as before.

  _initialize() — DarwinInitializationSettings now has requestAlertPermission/Badge/Sound all set to false, so the OS
  permission dialog is never triggered automatically on cold start — only when the user explicitly enables notifications
   via the settings toggle. The defaultPresent* flags are left at their package defaults (true), which keeps foreground
  notification display working on iOS.

  _requestNotificationsPermission() — Android path now calls requestNotificationsPermission() first (returns true
  immediately with no dialog if already granted, shows OS dialog if not). If that returns false/null (e.g. activity
  context unavailable), falls back to areNotificationsEnabled() as a secondary authoritative check. iOS path calls
  ios.requestPermissions() explicitly — previously it was never called at all, so the OS dialog on iOS was never shown.

  _scheduleDaily() — AndroidScheduleMode.inexact → AndroidScheduleMode.inexactAllowWhileIdle. The old mode could be
  skipped entirely during Android Doze windows overnight. inexactAllowWhileIdle fires even during Doze.

  ---
  lib/notification_settings.dart

  Added _hasPromptedKey, hasPromptedForPermission(), and setHasPromptedForPermission() to track whether the OS
  permission dialog has been shown before, so it only auto-fires on truly fresh installs.

  ---
  android/app/proguard-rules.pro (new file)

  -keep class com.dexterous.** { *; }

  Prevents R8 from stripping the flutter_local_notifications receiver classes in release builds. Without this, the alarm
   fires but the receiver can't deserialize the notification data — nothing is shown.

  ---
  android/app/build.gradle.kts

  Added proguardFiles(...) to the release build type so the rules above are actually applied by R8.

  ---
  android/app/src/main/AndroidManifest.xml

  Removed SCHEDULE_EXACT_ALARM permission. It was declared but the code was using inexact scheduling — a contradiction.
  On Android 14+, having this declared without proper runtime handling actively caused failures on fresh installs.