### PR TITLE
Fix/mark as read no scroll fallback

### DIFF
--- a/lib/screens/reader/reader_screen.dart
+++ b/lib/screens/reader/reader_screen.dart
@@ -70,7 +70,7 @@ class _ReaderScreenState extends State<ReaderScreen>
   }
 
   // Below this, remaining scroll distance is too small to reliably land on maxScrollExtent.
-  static const double _negligibleScrollExtent = 24;
+  static const double _negligibleScrollExtent = 150;
 
   void _checkScrollNeeded() {
     if (!mounted || !_scrollController.hasClients) return;

--- a/lib/screens/reader/reader_screen.dart
+++ b/lib/screens/reader/reader_screen.dart
@@ -56,7 +56,8 @@ class _ReaderScreenState extends State<ReaderScreen>
   }
 
   void _onScrollEnd() {
-    // Below the negligible-scroll threshold, only the manual button marks as read.
+    // Below the negligible-scroll threshold, only the manual button marks
+    // as read.
     if (_contentFitsWithoutScroll) return;
     if (_scrollController.position.pixels ==
         _scrollController.position.maxScrollExtent) {
@@ -64,12 +65,14 @@ class _ReaderScreenState extends State<ReaderScreen>
     }
   }
 
-  // Catches content-size changes (e.g. font-size setting) that ScrollController listeners miss.
+  // Catches content-size changes (e.g. font-size setting) that
+  // ScrollController listeners miss.
   void _scheduleScrollCheck() {
     WidgetsBinding.instance.addPostFrameCallback((_) => _checkScrollNeeded());
   }
 
-  // Below this, remaining scroll distance is too small to reliably land on maxScrollExtent.
+  // Below this, remaining scroll distance is too small to reliably land
+  // on maxScrollExtent.
   static const double _negligibleScrollExtent = 150;
 
   void _checkScrollNeeded() {

--- a/lib/screens/reader/reader_screen.dart
+++ b/lib/screens/reader/reader_screen.dart
@@ -39,27 +39,56 @@ class ReaderScreen extends StatefulWidget {
   State<ReaderScreen> createState() => _ReaderScreenState();
 }
 
-class _ReaderScreenState extends State<ReaderScreen> {
+class _ReaderScreenState extends State<ReaderScreen>
+    with WidgetsBindingObserver {
   late final ScrollController _scrollController;
   double _horizontalDragDistance = 0;
   double _verticalDragDistance = 0;
   bool _isHorizontalSwipe = false;
+  bool _contentFitsWithoutScroll = false;
+  late DateTime _currentDate = widget.date;
 
   @override
   void initState() {
     super.initState();
     _scrollController = ScrollController()..addListener(_onScrollEnd);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   void _onScrollEnd() {
+    // Below the negligible-scroll threshold, only the manual button marks as read.
+    if (_contentFitsWithoutScroll) return;
     if (_scrollController.position.pixels ==
         _scrollController.position.maxScrollExtent) {
-      context.read<ReadingBloc>().add(MarkAsReadEvent(widget.date));
+      context.read<ReadingBloc>().add(MarkAsReadEvent(_currentDate));
+    }
+  }
+
+  // Catches content-size changes (e.g. font-size setting) that ScrollController listeners miss.
+  void _scheduleScrollCheck() {
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkScrollNeeded());
+  }
+
+  // Below this, remaining scroll distance is too small to reliably land on maxScrollExtent.
+  static const double _negligibleScrollExtent = 24;
+
+  void _checkScrollNeeded() {
+    if (!mounted || !_scrollController.hasClients) return;
+    final fitsWithoutScroll =
+        _scrollController.position.maxScrollExtent <= _negligibleScrollExtent;
+    if (fitsWithoutScroll != _contentFitsWithoutScroll) {
+      setState(() => _contentFitsWithoutScroll = fitsWithoutScroll);
     }
   }
 
   @override
+  void didChangeMetrics() {
+    _scheduleScrollCheck();
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _scrollController
       ..removeListener(_onScrollEnd)
       ..dispose();
@@ -68,7 +97,13 @@ class _ReaderScreenState extends State<ReaderScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<ReadingBloc, ReadingState>(
+    return BlocConsumer<ReadingBloc, ReadingState>(
+      listener: (context, state) {
+        if (state is ReadingLoaded) {
+          _currentDate = state.currentDate;
+          _scheduleScrollCheck();
+        }
+      },
       builder: (context, state) {
         if (state is ReadingLoading) {
           return const Center(child: CircularProgressIndicator());
@@ -221,80 +256,95 @@ class _ReaderScreenState extends State<ReaderScreen> {
                     _verticalDragDistance = 0.0;
                     _isHorizontalSwipe = false;
                   },
-                  child: SingleChildScrollView(
-                    controller: _scrollController,
-                    child: Scrollbar(
-                      child: Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: TweenAnimationBuilder<double>(
-                          key: ValueKey(state.reading.date),
-                          duration: const Duration(milliseconds: 200),
-                          tween: Tween(begin: 0, end: 1),
-                          builder: (context, value, child) {
-                            return Opacity(opacity: value, child: child);
-                          },
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                state.reading.scripture.replaceAll('\n', ' '),
-                                textAlign: TextAlign.center,
-                                style: AppFonts.italics(
-                                  context,
-                                ).copyWith(fontSize: fontSize),
-                                textScaler: TextScaler.noScaling,
-                              ),
-                              const SizedBox(height: 8),
-                              Center(
-                                child: Image.asset(
-                                  'assets/icon/divider.png',
-                                  color:
-                                      context.isDarkMode ? Colors.white : null,
-                                  width: (fontSize * 20).clamp(0, 400),
+                  child: NotificationListener<ScrollMetricsNotification>(
+                    onNotification: (notification) {
+                      _scheduleScrollCheck();
+                      return false;
+                    },
+                    child: SingleChildScrollView(
+                      controller: _scrollController,
+                      child: Scrollbar(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: TweenAnimationBuilder<double>(
+                            key: ValueKey(state.reading.date),
+                            duration: const Duration(milliseconds: 200),
+                            tween: Tween(begin: 0, end: 1),
+                            builder: (context, value, child) {
+                              return Opacity(opacity: value, child: child);
+                            },
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  state.reading.scripture.replaceAll('\n', ' '),
+                                  textAlign: TextAlign.center,
+                                  style: AppFonts.italics(
+                                    context,
+                                  ).copyWith(fontSize: fontSize),
+                                  textScaler: TextScaler.noScaling,
                                 ),
-                              ),
+                                const SizedBox(height: 8),
+                                Center(
+                                  child: Image.asset(
+                                    'assets/icon/divider.png',
+                                    color:
+                                        context.isDarkMode
+                                            ? Colors.white
+                                            : null,
+                                    width: (fontSize * 20).clamp(0, 400),
+                                  ),
+                                ),
 
-                              const SizedBox(height: 8),
-                              DropCapText(
-                                dropCapStyle: TextStyle(
-                                  fontFamily: 'OldEnglish',
-                                  fontSize: 50,
-                                  color:
-                                      context.isDarkMode ? Colors.white : null,
+                                const SizedBox(height: 8),
+                                DropCapText(
+                                  dropCapStyle: TextStyle(
+                                    fontFamily: 'OldEnglish',
+                                    fontSize: 50,
+                                    color:
+                                        context.isDarkMode
+                                            ? Colors.white
+                                            : null,
+                                  ),
+                                  state.reading.quote,
+                                  textAlign: TextAlign.left,
+                                  style: AppFonts.normal(
+                                    context,
+                                  ).copyWith(fontSize: fontSize, height: 1.2),
+                                  dropCapPadding: const EdgeInsets.only(
+                                    right: 8,
+                                  ),
                                 ),
-                                state.reading.quote,
-                                textAlign: TextAlign.left,
-                                style: AppFonts.normal(
-                                  context,
-                                ).copyWith(fontSize: fontSize, height: 1.2),
-                                dropCapPadding: const EdgeInsets.only(right: 8),
-                              ),
-                              const SizedBox(height: 8),
-                              Text(
-                                state.reading.title,
-                                textAlign: TextAlign.left,
-                                style: AppFonts.italics(
-                                  context,
-                                ).copyWith(fontSize: fontSize),
-                              ),
-                              const SizedBox(height: 8),
-                              Center(
-                                child: Image.asset(
-                                  'assets/icon/divider.png',
-                                  color:
-                                      context.isDarkMode ? Colors.white : null,
-                                  width: (fontSize * 20).clamp(0, 400),
+                                const SizedBox(height: 8),
+                                Text(
+                                  state.reading.title,
+                                  textAlign: TextAlign.left,
+                                  style: AppFonts.italics(
+                                    context,
+                                  ).copyWith(fontSize: fontSize),
                                 ),
-                              ),
-                              const SizedBox(height: 8),
-                              Text(
-                                'Daily Reading: ${state.reading.dailyReading}',
-                                textAlign: TextAlign.left,
-                                style: AppFonts.normal(
-                                  context,
-                                ).copyWith(fontSize: fontSize),
-                              ),
-                            ],
+                                const SizedBox(height: 8),
+                                Center(
+                                  child: Image.asset(
+                                    'assets/icon/divider.png',
+                                    color:
+                                        context.isDarkMode
+                                            ? Colors.white
+                                            : null,
+                                    width: (fontSize * 20).clamp(0, 400),
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Text(
+                                  'Daily Reading: '
+                                  '${state.reading.dailyReading}',
+                                  textAlign: TextAlign.left,
+                                  style: AppFonts.normal(
+                                    context,
+                                  ).copyWith(fontSize: fontSize),
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       ),
@@ -327,6 +377,26 @@ class _ReaderScreenState extends State<ReaderScreen> {
                               ),
                             },
                       ),
+                      if (_contentFitsWithoutScroll &&
+                          !state.isCurrentDayRead())
+                        FilledButton.icon(
+                          onPressed:
+                              () => context.read<ReadingBloc>().add(
+                                MarkAsReadEvent(_currentDate),
+                              ),
+                          style: FilledButton.styleFrom(
+                            backgroundColor: AppColors.dialogMarkReadBG,
+                          ),
+                          icon: const Icon(
+                            Icons.check,
+                            color: AppColors.dialogButtonText,
+                            size: 18,
+                          ),
+                          label: const Text(
+                            'Mark as Read',
+                            style: TextStyle(color: AppColors.dialogButtonText),
+                          ),
+                        ),
                       IconButton(
                         color: context.textColor,
                         icon: const Icon(Icons.arrow_circle_right_outlined),

--- a/lib/widgets/calendar_widget.dart
+++ b/lib/widgets/calendar_widget.dart
@@ -63,16 +63,13 @@ class _FamilyAltarCalendarState extends State<FamilyAltarCalendar>
     return isLeapYear ? 366 : 365;
   }
 
-  String _calculateCompletionPercentage(ReadingLoaded? loadedState) {
-    if (loadedState == null) return '0';
-
+  String _calculateCompletionProgress(ReadingLoaded? loadedState) {
     // Completed count only (excludes missed).
     // Denominator = days in current year.
-    final completedCount = loadedState.getTotalCompletedDaysCount();
+    final completedCount = loadedState?.getTotalCompletedDaysCount() ?? 0;
     final daysInYear = _daysInYear(DateTime.now().year);
-    final percentage = (completedCount / daysInYear) * 100;
 
-    return percentage.clamp(0.0, 100.0).toStringAsFixed(0);
+    return '$completedCount / $daysInYear';
   }
 
   void _onCalendarViewChanged(ViewChangedDetails details) {
@@ -196,7 +193,7 @@ class _FamilyAltarCalendarState extends State<FamilyAltarCalendar>
 
   Widget _buildStatsBar(
     BuildContext context,
-    String percentage,
+    String progress,
     int missedCount,
   ) {
     return Container(
@@ -212,7 +209,7 @@ class _FamilyAltarCalendarState extends State<FamilyAltarCalendar>
           Icon(Icons.check, size: 18, color: Colors.green.shade400),
           const SizedBox(width: 8),
           Text(
-            '$percentage% Completed',
+            '$progress Read',
             style: AppFonts.normal(context, size: FontSize.small).copyWith(
               fontWeight: FontWeight.w600,
               color: context.calendarDayTextSecondary,
@@ -242,9 +239,7 @@ class _FamilyAltarCalendarState extends State<FamilyAltarCalendar>
       builder: (context, state) {
         final loadedState = state is ReadingLoaded ? state : null;
         final missedDaysCount = loadedState?.getTotalMissedDaysCount() ?? 0;
-        final completionPercentage = _calculateCompletionPercentage(
-          loadedState,
-        );
+        final completionProgress = _calculateCompletionProgress(loadedState);
 
         // Avoid constantly ticking animation when there are no missed days.
         if (missedDaysCount > 0) {
@@ -360,7 +355,7 @@ class _FamilyAltarCalendarState extends State<FamilyAltarCalendar>
             );
 
             final topSection = <Widget>[
-              _buildStatsBar(context, completionPercentage, missedDaysCount),
+              _buildStatsBar(context, completionProgress, missedDaysCount),
               _buildHeader(context),
             ];
 


### PR DESCRIPTION
## Summary

- Fixed short readings never trig

https://github.com/user-attachments/assets/9776369c-4785-4b58-8390-b97f27fa9424

gering "mark as read" by adding a manual button when little/no scrolling is needed.
- Fixed misleading rounded completion percentage on the calendar by showing a plain "X / Y Read" fraction instead.
